### PR TITLE
Fix Auth and add example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.egg-info
 dist/
+venv/
+.vscode/
+__pycache__

--- a/examples/presence.py
+++ b/examples/presence.py
@@ -1,0 +1,97 @@
+"""
+Example scripts that performs authentication
+"""
+import argparse
+import asyncio
+import os
+import webbrowser
+
+from aiohttp import ClientSession, web
+
+from hagraphapi.auth.manager import AuthManager
+from hagraphapi.client import GraphApiClient
+
+
+CLIENT_ID = ""
+CLIENT_SECRET = ""
+REDIRECT_URI = "http://localhost:8080/auth/callback"
+
+queue = asyncio.Queue(1)
+
+
+async def auth_callback(request):
+    error = request.query.get("error")
+    if error:
+        description = request.query.get("error_description")
+        print(f"Error in auth_callback: {description}")
+
+    # Run in task to not make unsuccessful parsing the HTTP response fail
+    asyncio.create_task(queue.put(request.query.get("code")))
+    return web.Response(
+        headers={"content-type": "text/html"},
+        text="<html><body><h1>Auth Completed</h1></body></html>",
+    )
+
+
+async def async_main(
+    client_id: str, client_secret: str, redirect_uri: str
+):
+
+    async with ClientSession() as session:
+        auth_mgr = AuthManager(
+            session, client_id, client_secret, redirect_uri
+        )
+
+        auth_url = auth_mgr.generate_authorization_url()
+        webbrowser.open(auth_url)
+        code = await queue.get()
+
+        if not code:
+            return
+
+        await auth_mgr.request_token(code)
+
+        # Make presence call
+        client = GraphApiClient(auth_mgr)
+        resp = await client.presence.get_presence()
+        print(resp.json())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Authenticate with Microsoft Graph")
+    parser.add_argument(
+        "--client-id",
+        "-cid",
+        default=os.environ.get("CLIENT_ID", CLIENT_ID),
+        help="OAuth2 Client ID",
+    )
+    parser.add_argument(
+        "--client-secret",
+        "-cs",
+        default=os.environ.get("CLIENT_SECRET", CLIENT_SECRET),
+        help="OAuth2 Client Secret",
+    )
+    parser.add_argument(
+        "--redirect-uri",
+        "-ru",
+        default=os.environ.get("REDIRECT_URI", REDIRECT_URI),
+        help="OAuth2 Redirect URI",
+    )
+
+    args = parser.parse_args()
+
+    app = web.Application()
+    app.add_routes([web.get("/auth/callback", auth_callback)])
+    runner = web.AppRunner(app)
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(runner.setup())
+    site = web.TCPSite(runner, "localhost", 8080)
+    loop.run_until_complete(site.start())
+    loop.run_until_complete(
+        async_main(args.client_id, args.client_secret, args.redirect_uri)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/hagraphapi/auth/manager.py
+++ b/hagraphapi/auth/manager.py
@@ -2,36 +2,101 @@
 Authentication Manager
 Authenticate with Microsoft Online.
 """
+from abc import ABC, abstractmethod
 import logging
-from typing import List, Optional
+from typing import Any, List, Optional
 
+from aiohttp import hdrs
 import aiohttp
+from aiohttp.client import ClientSession, ClientResponse
 from yarl import URL
 
-from api.auth.models import OAuth2TokenResponse
+from .models import OAuth2TokenResponse
 
 log = logging.getLogger("authentication")
 
-DEFAULT_SCOPES = ["Presence.Read", "Presence.Read.All"]
+DEFAULT_SCOPES = ["https://graph.microsoft.com/.default"]
 AUTHORITY = "https://login.microsoftonline.com/common"
-# ENDPOINT = 'https://graph.microsoft.com/v1.0/users'
 
-class AuthenticationManager:
+class AbstractAuth(ABC):
+    """Abstract class to make authenticated requests."""
+
+    def __init__(self, client_session: ClientSession):
+        self.session: ClientSession = client_session
+
+    @abstractmethod
+    async def async_get_access_token(self) -> str:
+        """Return a valid access token."""
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> ClientResponse:
+        """Make a request."""
+        headers = kwargs.get("headers")
+
+        if headers is None:
+            headers = {}
+        else:
+            headers = dict(headers)
+
+        access_token = await self.async_get_access_token()
+        headers["authorization"] = f"Bearer {access_token}"
+
+        return await self.session.request(
+            method, url, **kwargs, headers=headers,
+        )
+
+    async def get(self, url: str, **kwargs: Any) -> ClientResponse:
+        return await self.request(hdrs.METH_GET, url, **kwargs)
+
+    async def options(self, url: str, **kwargs: Any) -> ClientResponse:
+        return await self.request(hdrs.METH_OPTIONS, url, **kwargs)
+
+    async def head(self, url: str, **kwargs: Any) -> ClientResponse:
+        return await self.request(hdrs.METH_HEAD, url, **kwargs)
+
+    async def post(self, url: str, **kwargs: Any) -> ClientResponse:
+        return await self.request(hdrs.METH_POST, url, **kwargs)
+
+    async def put(self, url: str, **kwargs: Any) -> ClientResponse:
+        return await self.request(hdrs.METH_PUT, url, **kwargs)
+
+    async def patch(self, url: str, **kwargs: Any) -> ClientResponse:
+        return await self.request(hdrs.METH_PATCH, url, **kwargs)
+
+    async def delete(self, url: str, **kwargs: Any) -> ClientResponse:
+        return await self.request(hdrs.METH_DELETE, url, **kwargs)
+
+
+class AuthManager(AbstractAuth):
     def __init__(
         self,
-        client_session: aiohttp.ClientSession,
+        client_session: ClientSession,
         client_id: str,
         client_secret: str,
         redirect_uri: str,
         scopes: Optional[List[str]] = None,
     ):
-        self.session: aiohttp.ClientSession = client_session
+        self.session: ClientSession = client_session
         self._client_id: str = client_id
         self._client_secret: str = client_secret
         self._redirect_uri: str = redirect_uri
         self._scopes: List[str] = scopes or DEFAULT_SCOPES
 
         self.oauth: OAuth2TokenResponse = None
+
+    async def async_get_access_token(self) -> str:
+        """Return a valid access token."""
+        if not self.oauth:
+            raise NotAuthenticated()
+
+        if not self.oauth.is_valid():
+            await self.refresh_token()
+
+        return self.oauth.access_token
 
     def generate_authorization_url(self, state: Optional[str] = None) -> str:
         """Generate Microsoft Authorization URL."""
@@ -51,18 +116,9 @@ class AuthenticationManager:
             URL(AUTHORITY + "/oauth2/v2.0/authorize").with_query(query_string)
         )
 
-    async def request_tokens(self, authorization_code: str) -> None:
-        """Request all tokens."""
-        self.oauth = await self.request_oauth_token(authorization_code)
-
-    async def refresh_tokens(self) -> None:
-        """Refresh all tokens."""
-        if not (self.oauth and self.oauth.is_valid()):
-            self.oauth = await self.refresh_oauth_token()
-
-    async def request_oauth_token(self, authorization_code: str) -> OAuth2TokenResponse:
+    async def request_token(self, authorization_code: str) -> None:
         """Request OAuth2 token."""
-        return await self._oauth2_token_request(
+        self.oauth = await self._oauth2_token_request(
             {
                 "grant_type": "authorization_code",
                 "code": authorization_code,
@@ -71,9 +127,9 @@ class AuthenticationManager:
             }
         )
 
-    async def refresh_oauth_token(self) -> OAuth2TokenResponse:
+    async def refresh_token(self) -> None:
         """Refresh OAuth2 token."""
-        return await self._oauth2_token_request(
+        self.oauth = await self._oauth2_token_request(
             {
                 "grant_type": "refresh_token",
                 "scope": " ".join(self._scopes),
@@ -84,17 +140,14 @@ class AuthenticationManager:
     async def _oauth2_token_request(self, data: dict) -> OAuth2TokenResponse:
         """Execute token requests."""
         data["client_id"] = self._client_id
-        data["grant_type"] = self._grant_type
-        data["scope"] = self._scope
-        data["code"] = self._code
-        data["redirect_uri"] = self._redirect_uri
-
         if self._client_secret:
-            data["client_secret"] = self._client_secret
-            
+            data["client_secret"] = self._client_secret 
         resp = await self.session.post(
             AUTHORITY + "/oauth2/v2.0/token", data=data
         )
-        # print(await resp.content.read())
         resp.raise_for_status()
         return OAuth2TokenResponse.parse_raw(await resp.text())
+
+
+class NotAuthenticated(Exception):
+    """User not authenticated."""

--- a/hagraphapi/auth/models.py
+++ b/hagraphapi/auth/models.py
@@ -1,8 +1,12 @@
 """Authentication Models."""
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from pydantic import BaseModel, Field
 
+
+def utc_now():
+    return datetime.now(timezone.utc)
 
 class OAuth2TokenResponse(BaseModel):
     token_type: str
@@ -10,3 +14,7 @@ class OAuth2TokenResponse(BaseModel):
     scope: str
     access_token: str
     refresh_token: Optional[str]
+    issued: datetime = Field(default_factory=utc_now)
+
+    def is_valid(self) -> bool:
+        return (self.issued + timedelta(seconds=self.expires_in)) > utc_now()

--- a/hagraphapi/client.py
+++ b/hagraphapi/client.py
@@ -2,96 +2,17 @@
 Microsoft Graph API Client
 """
 import logging
-from typing import Any
-
-from aiohttp import hdrs
-from aiohttp.client import ClientResponse
-from ms_cv import CorrelationVector
 
 from .provider.presence import PresenceProvider
-from .auth.manager import AuthenticationManager
+from .auth.manager import AbstractAuth
 
 log = logging.getLogger("microsoft.graph.api")
-
-
-class Session:
-    def __init__(self, auth_mgr: AuthenticationManager):
-        self._auth_mgr = auth_mgr
-        self._cv = CorrelationVector()
-
-    async def request(
-        self,
-        method: str,
-        url: str,
-        include_auth: bool = True,
-        include_cv: bool = True,
-        **kwargs: Any,
-    ) -> ClientResponse:
-        """Proxy Request and add Auth/CV headers."""
-        headers = kwargs.pop("headers", {})
-        params = kwargs.pop("params", None)
-        data = kwargs.pop("data", None)
-
-        # Extra, user supplied values
-        extra_headers = kwargs.pop("extra_headers", None)
-        extra_params = kwargs.pop("extra_params", None)
-        extra_data = kwargs.pop("extra_data", None)
-
-        if include_auth:
-            # Ensure tokens valid
-            await self._auth_mgr.refresh_tokens()
-            # Set auth header
-            headers[
-                hdrs.AUTHORIZATION
-            ] = self._auth_mgr.xsts_token.authorization_header_value
-
-        if include_cv:
-            headers["MS-CV"] = self._cv.increment()
-
-        # Extend with optionally supplied values
-        if extra_headers:
-            headers.update(extra_headers)
-        if extra_params:
-            # query parameters
-            params = params or {}
-            params.update(extra_params)
-        if extra_data:
-            # form encoded post data
-            data = data or {}
-            data.update(extra_data)
-
-        return await self._auth_mgr.session.request(
-            method, url, **kwargs, headers=headers, params=params, data=data
-        )
-
-    async def get(self, url: str, **kwargs: Any) -> ClientResponse:
-        return await self.request(hdrs.METH_GET, url, **kwargs)
-
-    async def options(self, url: str, **kwargs: Any) -> ClientResponse:
-        return await self.request(hdrs.METH_OPTIONS, url, **kwargs)
-
-    async def head(self, url: str, **kwargs: Any) -> ClientResponse:
-        return await self.request(hdrs.METH_HEAD, url, **kwargs)
-
-    async def post(self, url: str, **kwargs: Any) -> ClientResponse:
-        return await self.request(hdrs.METH_POST, url, **kwargs)
-
-    async def put(self, url: str, **kwargs: Any) -> ClientResponse:
-        return await self.request(hdrs.METH_PUT, url, **kwargs)
-
-    async def patch(self, url: str, **kwargs: Any) -> ClientResponse:
-        return await self.request(hdrs.METH_PATCH, url, **kwargs)
-
-    async def delete(self, url: str, **kwargs: Any) -> ClientResponse:
-        return await self.request(hdrs.METH_DELETE, url, **kwargs)
-
 
 class GraphApiClient:
     def __init__(
         self,
-        auth_mgr: AuthenticationManager,
+        auth_mgr: AbstractAuth,
     ):
-        self._auth_mgr = auth_mgr
-        self.session = Session(auth_mgr)
+        self.session = auth_mgr
 
         self.presence = PresenceProvider(self)

--- a/hagraphapi/provider/presence/__init__.py
+++ b/hagraphapi/provider/presence/__init__.py
@@ -2,7 +2,7 @@
 Presence
 Get user presence for authenticated user or a specified user by ID
 """
-from typing import List
+from aiohttp.client import ClientResponse
 
 from ..baseprovider import BaseProvider
 from .models import PresenceResponse
@@ -10,33 +10,28 @@ from .models import PresenceResponse
 
 class PresenceProvider(BaseProvider):
     BASE_URL = "https://graph.microsoft.com/beta"
-    SEPARATOR = ","
 
-    async def get_presence(self, **kwargs) -> PresenceResponse:
+    async def get_presence(self) -> PresenceResponse:
         """
         Get presence info for the current user
         Returns:
             :class:`PresenceResponse`: Presence Response
         """
-        url = self.BASE_URL + "/me/presence"
-        resp = await self.client.session.get(
-            url, headers=self.HEADERS_PRESENCE, **kwargs
-        )
+        url = f"{self.BASE_URL}/me/presence"
+        resp = await self.client.session.get(url)
         resp.raise_for_status()
         return PresenceResponse.parse_raw(await resp.text())
 
-    async def get_presence_by_id(self, target_id: str, **kwargs) -> PresenceResponse:
+    async def get_presence_by_id(self, target_id: str) -> PresenceResponse:
         """
-        Get Userpresence by xuid
+        Get Userpresence by User ID
         Args:
-            target_xuid: XUID to get presence for
+            target_id: User ID to get presence for
         Returns:
             :class:`PresenceResponse`: Presence Response
         """
         # https://graph.microsoft.com/beta/users/{user-id}/presence
-        url = self.BASE_URL + f"/users/{target_id}/presence"
-        resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_PRESENCE, **kwargs
-        )
+        url = f"{self.BASE_URL}/users/{target_id}/presence"
+        resp = await self.client.session.get(url)
         resp.raise_for_status()
         return PresenceResponse.parse_raw(await resp.text())


### PR DESCRIPTION
You can test presence (if your client is setup correctly) by running the following:
```bash
python3 examples/presence.py --client_id {my-client-id} --client_secret {my-client-secret}
```

Notes:
1) The example expects you to have created a venv and installed locally via `pip3 install -e .`
2) Microsoft doesn't let business accounts use non-verified app clients that are created after Nov. 9, 2020. You will need to go through the Microsoft Partner Network verification process.
3) I went down a rabbit hole that I ultimately abandoned trying to auto-generate pydantic models from the [Graph OpenAPI specs](https://github.com/microsoftgraph/microsoft-graph-openapi). **Don't bother**... the models are too complex for current codegen to process. I would actually recommend abandoning pydantic all together for the providers and just create a blank `__init__.py` under the providers directory, and include `presence.py`, `user.py` with no models just returning the dictionary from `await resp.json()`.
4) Home Assistant will **not** use the `AuthManager` class. It will just implement the `AbstractAuth` class and return the access token in the implementation for `async_get_access_token` in the `api.py` file provided by the [scaffolding script](https://github.com/home-assistant/core/blob/dev/script/scaffold/templates/config_flow_oauth2/integration/api.py#L41-L58)